### PR TITLE
Refactor

### DIFF
--- a/handlers/event.js
+++ b/handlers/event.js
@@ -18,7 +18,7 @@ const handleDocument = async (document) => {
   }
 }
 
-const handler = async (lambdaEvent) => {
+export const handler = async (lambdaEvent) => {
   try {
     const srcBucket = lambdaEvent['Records'][0].s3.bucket.name
     const srcKey = decodeURIComponent(lambdaEvent.Records[0].s3.object.key.replace(/\+/g, ' '))
@@ -35,9 +35,4 @@ const handler = async (lambdaEvent) => {
     await rollbar.error('handler error', error, { lambdaEvent })
     throw error
   }
-}
-
-module.exports = {
-  handler: handler,
-  handleDocument: handleDocument
 }

--- a/handlers/event.js
+++ b/handlers/event.js
@@ -3,18 +3,9 @@
 import rollbar from '../config/rollbar'
 import AWS from 'aws-sdk'
 import cloudsearchService from '../services/cloudsearch-service'
+import parsingService from '../services/parsing-service'
 
 const s3 = new AWS.S3()
-
-/**
- * Parses the S3 document into the fields we care about for CloudSearch.
- * @param document an object from S3 with metadata and HTTP response data
- * @returns the parsed data as an object
- */
-const parseDocument = async (document) => {
-  // TODO: Implement
-  return document
-}
 
 /**
  * Handles an incoming S3 response (from s3.getObject()).
@@ -22,7 +13,7 @@ const parseDocument = async (document) => {
 const handleDocument = async (document) => {
   // TODO: Implement
   if (document.ContentType === 'text/html') {
-    const searchObject = await parseDocument(document)
+    const searchObject = await parsingService.parseDocument(document)
     await cloudsearchService.sendToCloudsearch(searchObject)
   }
 }
@@ -48,6 +39,5 @@ const handler = async (lambdaEvent) => {
 
 module.exports = {
   handler: handler,
-  handleDocument: handleDocument,
-  parseDocument: parseDocument
+  handleDocument: handleDocument
 }

--- a/handlers/event.js
+++ b/handlers/event.js
@@ -2,57 +2,9 @@
 
 import rollbar from '../config/rollbar'
 import AWS from 'aws-sdk'
-import crypto from 'crypto'
-
-const MAX_ID_SIZE = 128
+import cloudsearchService from '../services/cloudsearch-service'
 
 const s3 = new AWS.S3()
-const cloudsearch = new AWS.CloudSearchDomain({ endpoint: process.env['CLOUDSEARCH_DOMAIN_ARN'] })
-
-/**
- * Returns either the page URL or an MD5 hashed ID if the URL is longer than 128 characters.
- */
-const buildId = (pageUrl) => {
-  if (pageUrl.length > MAX_ID_SIZE) {
-    let id = pageUrl
-    id = crypto.createHash('md5').update(id).digest('hex')
-    return id
-  }
-  return pageUrl
-}
-
-/**
- * Sends the already-parsed data to CloudSearch.
- *
- * @param searchObject an object with all the desired fields to send to CloudSearch
- * @returns {Promise<void>}
- */
-const sendToCloudsearch = async (searchObject) => {
-  const searchDocument = {
-    id: buildId(searchObject.path),
-    type: 'add',
-    fields: searchObject
-  }
-  const cloudsearchRequest = {
-    contentType: 'application/json',
-    documents: JSON.stringify(searchDocument)
-  }
-
-  cloudsearch.uploadDocuments(cloudsearchRequest, (err, data) => {
-    if (err) {
-      throw err
-    }
-    if (data.warnings) {
-      data.warnings.map(warning => {
-        rollbar.warn(`Warning from batch upload: ${warning.message}`)
-      })
-    }
-    if (data.adds !== 1) {
-      rollbar.warn(`We sent 1 add document, but ${data.adds} documents were added.`)
-    }
-    return `Added ${data.adds} documents.`
-  })
-}
 
 /**
  * Parses the S3 document into the fields we care about for CloudSearch.
@@ -71,7 +23,7 @@ const handleDocument = async (document) => {
   // TODO: Implement
   if (document.ContentType === 'text/html') {
     const searchObject = await parseDocument(document)
-    await sendToCloudsearch(searchObject)
+    await cloudsearchService.sendToCloudsearch(searchObject)
   }
 }
 
@@ -97,7 +49,5 @@ const handler = async (lambdaEvent) => {
 module.exports = {
   handler: handler,
   handleDocument: handleDocument,
-  parseDocument: parseDocument,
-  sendToCloudsearch: sendToCloudsearch,
-  buildId: buildId
+  parseDocument: parseDocument
 }

--- a/services/cloudsearch-service.js
+++ b/services/cloudsearch-service.js
@@ -23,7 +23,6 @@ const buildId = (pageUrl) => {
  * Sends the already-parsed data to CloudSearch.
  *
  * @param searchObject an object with all the desired fields to send to CloudSearch
- * @returns {Promise<void>}
  */
 const sendToCloudsearch = async (searchObject) => {
   const searchDocument = [{
@@ -36,20 +35,16 @@ const sendToCloudsearch = async (searchObject) => {
     documents: JSON.stringify(searchDocument)
   }
 
-  cloudsearch.uploadDocuments(cloudsearchRequest, (err, data) => {
-    if (err) {
-      throw err
-    }
-    if (data.warnings) {
-      data.warnings.map(warning => {
-        rollbar.warn(`Warning from batch upload: ${warning.message}`)
-      })
-    }
-    if (data.adds !== 1) {
-      rollbar.warn(`We sent 1 add document, but ${data.adds} documents were added.`)
-    }
-    return `Added ${data.adds} documents.`
-  })
+  const data = await cloudsearch.uploadDocuments(cloudsearchRequest).promise()
+  if (data.warnings) {
+    data.warnings.map(warning => {
+      rollbar.warn(`Warning from batch upload: ${warning.message}`)
+    })
+  }
+  if (data.adds !== 1) {
+    rollbar.warn(`We sent 1 add document, but ${data.adds} documents were added.`)
+  }
+  return `Added ${data.adds} documents.`
 }
 
 module.exports = {

--- a/services/cloudsearch-service.js
+++ b/services/cloudsearch-service.js
@@ -5,7 +5,7 @@ import AWS from 'aws-sdk'
 import crypto from 'crypto'
 
 const MAX_ID_SIZE = 128
-const cloudsearch = new AWS.CloudSearchDomain({ endpoint: process.env['CLOUDSEARCH_DOMAIN_ARN'] })
+const cloudsearch = new AWS.CloudSearchDomain({ endpoint: process.env['CLOUDSEARCH_DOCUMENT_ENDPOINT'] })
 
 /**
  * Returns either the page URL or an MD5 hashed ID if the URL is longer than 128 characters.

--- a/services/cloudsearch-service.js
+++ b/services/cloudsearch-service.js
@@ -1,0 +1,58 @@
+'use strict'
+
+import rollbar from '../config/rollbar'
+import AWS from 'aws-sdk'
+import crypto from 'crypto'
+
+const MAX_ID_SIZE = 128
+const cloudsearch = new AWS.CloudSearchDomain({ endpoint: process.env['CLOUDSEARCH_DOMAIN_ARN'] })
+
+/**
+ * Returns either the page URL or an MD5 hashed ID if the URL is longer than 128 characters.
+ */
+const buildId = (pageUrl) => {
+  if (pageUrl.length > MAX_ID_SIZE) {
+    let id = pageUrl
+    id = crypto.createHash('md5').update(id).digest('hex')
+    return id
+  }
+  return pageUrl
+}
+
+/**
+ * Sends the already-parsed data to CloudSearch.
+ *
+ * @param searchObject an object with all the desired fields to send to CloudSearch
+ * @returns {Promise<void>}
+ */
+const sendToCloudsearch = async (searchObject) => {
+  const searchDocument = {
+    id: buildId(searchObject.path),
+    type: 'add',
+    fields: searchObject
+  }
+  const cloudsearchRequest = {
+    contentType: 'application/json',
+    documents: JSON.stringify(searchDocument)
+  }
+
+  cloudsearch.uploadDocuments(cloudsearchRequest, (err, data) => {
+    if (err) {
+      throw err
+    }
+    if (data.warnings) {
+      data.warnings.map(warning => {
+        rollbar.warn(`Warning from batch upload: ${warning.message}`)
+      })
+    }
+    if (data.adds !== 1) {
+      rollbar.warn(`We sent 1 add document, but ${data.adds} documents were added.`)
+    }
+    return `Added ${data.adds} documents.`
+  })
+}
+
+module.exports = {
+  sendToCloudsearch: sendToCloudsearch,
+  buildId: buildId
+}

--- a/services/cloudsearch-service.js
+++ b/services/cloudsearch-service.js
@@ -26,11 +26,11 @@ const buildId = (pageUrl) => {
  * @returns {Promise<void>}
  */
 const sendToCloudsearch = async (searchObject) => {
-  const searchDocument = {
+  const searchDocument = [{
     id: buildId(searchObject.path),
     type: 'add',
     fields: searchObject
-  }
+  }]
   const cloudsearchRequest = {
     contentType: 'application/json',
     documents: JSON.stringify(searchDocument)

--- a/services/parsing-service.js
+++ b/services/parsing-service.js
@@ -1,0 +1,15 @@
+'use strict'
+
+/**
+ * Parses the S3 document into the fields we care about for CloudSearch.
+ * @param document an object from S3 with metadata and HTTP response data
+ * @returns the parsed data as an object
+ */
+const parseDocument = async (document) => {
+  // TODO: Implement
+  return document
+}
+
+module.exports = {
+  parseDocument: parseDocument
+}

--- a/tests/handlers/event-e2e.test.js
+++ b/tests/handlers/event-e2e.test.js
@@ -1,6 +1,7 @@
 'use strict'
 
 import eventHandler from '../../handlers/event'
+import cloudsearchService from '../../services/cloudsearch-service'
 import fs from 'fs'
 import path from 'path'
 
@@ -16,7 +17,7 @@ describe('Event Handler End to End', () => {
     lambdaEvent['Records'][0].s3.bucket.arn = `arn:aws:s3:::${process.env['BUCKET']}`
     lambdaEvent['Records'][0].s3.object.key = 'index.html'
 
-    jest.spyOn(eventHandler, 'sendToCloudsearch').mockImplementation(() => {})
+    jest.spyOn(cloudsearchService, 'sendToCloudsearch').mockImplementation(() => {})
 
     expect.assertions(1)
     const response = await eventHandler.handler(lambdaEvent)

--- a/tests/handlers/event-e2e.test.js
+++ b/tests/handlers/event-e2e.test.js
@@ -1,6 +1,6 @@
 'use strict'
 
-import eventHandler from '../../handlers/event'
+import * as eventHandler from '../../handlers/event'
 import cloudsearchService from '../../services/cloudsearch-service'
 import fs from 'fs'
 import path from 'path'

--- a/tests/handlers/event-e2e.test.js
+++ b/tests/handlers/event-e2e.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 import * as eventHandler from '../../handlers/event'
-import cloudsearchService from '../../services/cloudsearch-service'
+import parsingService from '../../services/parsing-service'
 import fs from 'fs'
 import path from 'path'
 
@@ -17,7 +17,12 @@ describe('Event Handler End to End', () => {
     lambdaEvent['Records'][0].s3.bucket.arn = `arn:aws:s3:::${process.env['BUCKET']}`
     lambdaEvent['Records'][0].s3.object.key = 'index.html'
 
-    jest.spyOn(cloudsearchService, 'sendToCloudsearch').mockImplementation(() => {})
+    jest.spyOn(parsingService, 'parseDocument').mockImplementation(() => Promise.resolve({
+      path: 'https://some-site.com/page',
+      title: 'My Title',
+      body: 'staff member aims to guide a wave of incoming students toward transformation',
+      'published_date': '2020-07-06T19:27:03.000Z'
+    }))
 
     expect.assertions(1)
     const response = await eventHandler.handler(lambdaEvent)

--- a/tests/handlers/event.test.js
+++ b/tests/handlers/event.test.js
@@ -1,7 +1,7 @@
 'use strict'
 
 import rollbar from '../../config/rollbar'
-import eventHandler from '../../handlers/event'
+import * as eventHandler from '../../handlers/event'
 import cloudsearchService from '../../services/cloudsearch-service'
 import parsingService from '../../services/parsing-service'
 import fs from 'fs'

--- a/tests/handlers/event.test.js
+++ b/tests/handlers/event.test.js
@@ -1,7 +1,8 @@
 'use strict'
 
 import rollbar from '../../config/rollbar'
-import eventHandler, { handler, buildId, sendToCloudsearch } from '../../handlers/event'
+import eventHandler from '../../handlers/event'
+import cloudsearchService from '../../services/cloudsearch-service'
 import fs from 'fs'
 import path from 'path'
 
@@ -10,24 +11,24 @@ import path from 'path'
 jest.mock('../../config/rollbar')
 jest.mock('aws-sdk')
 
-describe('Event Handler', () => {
+describe('Event eventHandler.handler', () => {
   let lambdaEvent
   beforeEach(() => {
     lambdaEvent = JSON.parse(fs.readFileSync(path.join(__fixturesDir, 'mock-s3-event.json'), 'utf-8'))
   })
 
   it('is defined', () => {
-    expect(handler).toBeDefined()
+    expect(eventHandler.handler).toBeDefined()
   })
 
   it('handles a simple html file', async () => {
     expect.assertions(1)
-    const response = await handler(lambdaEvent)
+    const response = await eventHandler.handler(lambdaEvent)
     expect(response).toEqual('true')
   })
 
   it('skips an image', async () => {
-    jest.spyOn(eventHandler, 'sendToCloudsearch').mockImplementation(() => {})
+    jest.spyOn(cloudsearchService, 'sendToCloudsearch').mockImplementation(() => {})
     jest.spyOn(eventHandler, 'parseDocument').mockImplementation(() => {})
 
     lambdaEvent.Records[0].s3.object.key = 'image'
@@ -35,13 +36,13 @@ describe('Event Handler', () => {
     expect.assertions(2)
     await eventHandler.handler(lambdaEvent)
     expect(eventHandler.parseDocument).not.toHaveBeenCalled()
-    expect(eventHandler.sendToCloudsearch).not.toHaveBeenCalled()
+    expect(cloudsearchService.sendToCloudsearch).not.toHaveBeenCalled()
   })
 
   it('logs to rollbar in case of an error', done => {
     lambdaEvent.Records[0].s3.object.key = 'fail'
 
-    handler(lambdaEvent).then(() => {
+    eventHandler.handler(lambdaEvent).then(() => {
       done.fail()
     }).catch(() => {
       expect(rollbar.error).toHaveBeenCalledWith(
@@ -50,49 +51,6 @@ describe('Event Handler', () => {
         { lambdaEvent }
       )
       done()
-    })
-  })
-
-  it('should throw an error if there is a problem uploading the search document', done => {
-    lambdaEvent.Records[0].s3.object.key = 'uploadFail'
-
-    handler(lambdaEvent).then(() => {
-      done.fail()
-    }).catch(() => {
-      expect(rollbar.error).toHaveBeenCalledWith(
-        'handler error',
-        new Error('Error for the purpose of unit testing'),
-        { lambdaEvent })
-      done()
-    })
-  })
-
-  describe('buildId', () => {
-    it('should hash the id before sending to CloudSearch if it is too long', () => {
-      const pageUrl = 'https://some-site.com/path/which-is/super-long/and/has-to-be-hashed/lorem-ipsum-dolor-sit-amet-consectetur-adipiscing-elit-sed-do.html'
-
-      const id = buildId(pageUrl)
-      expect(id).not.toEqual(pageUrl)
-    })
-  })
-
-  describe('sendToCloudSearch', () => {
-    it('should send warnings to Rollbar if there are warnings', async () => {
-      const searchObject = {
-        path: 'warnings'
-      }
-      expect.assertions(1)
-      await sendToCloudsearch(searchObject)
-      expect(rollbar.warn).toHaveBeenCalledWith('Warning from batch upload: Warning!')
-    })
-
-    it('should send a warning to Rollbar if the successful adds is not 1', async () => {
-      const searchObject = {
-        path: 'adds'
-      }
-      expect.assertions(1)
-      await sendToCloudsearch(searchObject)
-      expect(rollbar.warn).toHaveBeenCalledWith('We sent 1 add document, but 2 documents were added.')
     })
   })
 })

--- a/tests/handlers/event.test.js
+++ b/tests/handlers/event.test.js
@@ -3,6 +3,7 @@
 import rollbar from '../../config/rollbar'
 import eventHandler from '../../handlers/event'
 import cloudsearchService from '../../services/cloudsearch-service'
+import parsingService from '../../services/parsing-service'
 import fs from 'fs'
 import path from 'path'
 
@@ -29,13 +30,13 @@ describe('Event eventHandler.handler', () => {
 
   it('skips an image', async () => {
     jest.spyOn(cloudsearchService, 'sendToCloudsearch').mockImplementation(() => {})
-    jest.spyOn(eventHandler, 'parseDocument').mockImplementation(() => {})
+    jest.spyOn(parsingService, 'parseDocument').mockImplementation(() => {})
 
     lambdaEvent.Records[0].s3.object.key = 'image'
 
     expect.assertions(2)
     await eventHandler.handler(lambdaEvent)
-    expect(eventHandler.parseDocument).not.toHaveBeenCalled()
+    expect(parsingService.parseDocument).not.toHaveBeenCalled()
     expect(cloudsearchService.sendToCloudsearch).not.toHaveBeenCalled()
   })
 

--- a/tests/services/cloudsearch-service.test.js
+++ b/tests/services/cloudsearch-service.test.js
@@ -1,0 +1,51 @@
+'use strict'
+
+import cloudsearchService from '../../services/cloudsearch-service'
+import rollbar from '../../config/rollbar'
+
+jest.mock('../../config/rollbar')
+jest.mock('aws-sdk')
+
+describe('CloudSearch Service', () => {
+  describe('buildId', () => {
+    it('should hash the id before sending to CloudSearch if it is too long', () => {
+      const pageUrl = 'https://some-site.com/path/which-is/super-long/and/has-to-be-hashed/lorem-ipsum-dolor-sit-amet-consectetur-adipiscing-elit-sed-do.html'
+
+      const id = cloudsearchService.buildId(pageUrl)
+      expect(id).not.toEqual(pageUrl)
+    })
+  })
+
+  describe('sendToCloudSearch', () => {
+    it('should send warnings to Rollbar if there are warnings', async () => {
+      const searchObject = {
+        path: 'warnings'
+      }
+      expect.assertions(1)
+      await cloudsearchService.sendToCloudsearch(searchObject)
+      expect(rollbar.warn).toHaveBeenCalledWith('Warning from batch upload: Warning!')
+    })
+
+    it('should send a warning to Rollbar if the successful adds is not 1', async () => {
+      const searchObject = {
+        path: 'adds'
+      }
+      expect.assertions(1)
+      await cloudsearchService.sendToCloudsearch(searchObject)
+      expect(rollbar.warn).toHaveBeenCalledWith('We sent 1 add document, but 2 documents were added.')
+    })
+
+    it('should throw an error if there is a problem uploading the search document', done => {
+      const searchObject = {
+        path: 'fail'
+      }
+
+      cloudsearchService.sendToCloudsearch(searchObject).then(() => {
+        done.fail('Should have thrown an error')
+      }).catch((err) => {
+        expect(err).toEqual(new Error('Error for the purpose of unit testing'))
+        done()
+      })
+    })
+  })
+})


### PR DESCRIPTION
This PR refactors the logic into services. One of the primary reasons for this was to make testing easier. While doing this, I was able to mock out the document parsing for the end-to-end test and found some issues with my implementation of sending to CloudSearch (#4), so this PR fixes those issues as well.

At this point, I have successfully retrieved an object from S3 and successfully sent an object to CloudSearch via the code in this project.