### PR TITLE
Send has_description field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,8 +69,7 @@ typings/
 .yarn-integrity
 
 # dotenv environment variables file
-.env
-.env.test
+*.env*
 
 # next.js build output
 .next

--- a/services/parsing-service.js
+++ b/services/parsing-service.js
@@ -21,6 +21,7 @@ const parseDocument = async (document, srcKey) => {
     path: path,
     title: title,
     description: description,
+    has_description: description ? 1 : 0,
     body: body,
     'image_url': imageUrl,
     'published_date': publishedDate


### PR DESCRIPTION
I have already run this in stage with successful results.

This PR sends an additional field `has_description` to cloudsearch. `1` if it has a description, `0` if not. This allows us to do more effective sorting (one of the requirements is to sort the pages with descriptions ahead of those without).