### PR TITLE
Fix export issue

### DIFF
--- a/handlers/event.js
+++ b/handlers/event.js
@@ -17,7 +17,7 @@ const handleDocument = async (document, srcKey) => {
   }
 }
 
-export const handler = async (lambdaEvent) => {
+const handler = async (lambdaEvent) => {
   try {
     const srcBucket = lambdaEvent['Records'][0].s3.bucket.name
     const srcKey = decodeURIComponent(lambdaEvent.Records[0].s3.object.key.replace(/\+/g, ' '))


### PR DESCRIPTION
Found in the [cloudwatch logs](https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logsV2:log-groups/log-group/$252Faws$252Flambda$252Fcloudsearch-s3-handler-staging-s3event/log-events/2020$252F09$252F15$252F$255B$2524LATEST$255D9daca4cdd8c846759b6f74438ba2fae0). Might be worth figuring out how to get this kind of error to Rollbar, since it did not make it there.