### PR TITLE
CRUORG-228 - add path literal

### DIFF
--- a/services/parsing-service.js
+++ b/services/parsing-service.js
@@ -24,7 +24,8 @@ const parseDocument = async (document, srcKey) => {
     has_description: description ? 1 : 0,
     body: body,
     'image_url': imageUrl,
-    'published_date': publishedDate
+    'published_date': publishedDate,
+    path_literal: path
   }
 }
 

--- a/tests/services/parsing-service.test.js
+++ b/tests/services/parsing-service.test.js
@@ -20,6 +20,7 @@ describe('Parsing Service', () => {
       expect(searchObject.body.indexOf('University of Nebraska–Lincoln student and part-time')).not.toEqual(-1)
       expect(searchObject.image_url).toEqual('https://mysite.com/og/default.png')
       expect(searchObject.published_date).not.toBeNull()
+      expect(searchObject.path_literal).not.toBeNull()
     })
   })
 


### PR DESCRIPTION
This PR just adds the `path` value to the new `path_literal` property. The properties are defined differently in CloudSearch, which is why there are two instead of one.

[Jira](https://jira.cru.org/browse/CRUORG-228)